### PR TITLE
Googleapis

### DIFF
--- a/modules/googleapis/googledrive/gdrive.be
+++ b/modules/googleapis/googledrive/gdrive.be
@@ -125,7 +125,7 @@ class google_drive
       return resp
     else
       print('file create failed' .. r .. s)
-      return resp
+      return s
     end
   end
   
@@ -192,7 +192,7 @@ class google_drive
   def cleanservicefiles(confirm)
     # find all files which are owned by the service account, and in the root drive.
     # file in a user's folder are not in the root drive, unless deleted by the user.
-    var resp = gdrive.readdir(nil, "%27me%27%20in%20owners%20and%20%27root%27%20in%20parents", "files(id,shared,name,kind,mimeType,parents,ownedByMe)")
+    var resp = self.readdir(nil, "%27me%27%20in%20owners%20and%20%27root%27%20in%20parents", "files(id,shared,name,kind,mimeType,parents,ownedByMe)")
     if resp.contains('files')
       var files = resp['files']
       var deleted = 0
@@ -204,7 +204,7 @@ class google_drive
           if !confirm
             print('would delete ' .. file['name'])
           else
-            resp = gdrive.delete(file['id'])
+            resp = self.delete(file['id'])
             print('deleted ' .. file['name'])
             deleted = deleted + 1
           end

--- a/modules/googleapis/googledrive/gdrivetest.be
+++ b/modules/googleapis/googledrive/gdrivetest.be
@@ -20,7 +20,7 @@ class gdrivetest
     # only create a new gdrive class if we don't have one
     if !global.gdrive
       var driveauth = google_oauth("/google.json", "https://www.googleapis.com/auth/drive");
-      global.gdrive = google_drive(auth)
+      global.gdrive = google_drive(driveauth)
       print('created new gdrive class')
     else
       print('use existing gdrive class')
@@ -56,7 +56,7 @@ class gdrivetest
     var pageToken = nil
     var pageSize = 4
     while count < maxcount
-      var resp = gdrive.readdir(nil, nil, "files(id,shared,name,kind,mimeType,parents,ownedByMe)", pageSize, pageToken)
+      var resp = global.gdrive.readdir(nil, nil, "files(id,shared,name,kind,mimeType,parents,ownedByMe)", pageSize, pageToken)
       var files = resp['files']
       if !size(files)
         break
@@ -92,7 +92,7 @@ class gdrivetest
     var pageSize = 4
     self.foldermap = {}
     while count < maxcount
-      var resp = gdrive.readdir(nil, "mimeType%20=%20%27application/vnd.google-apps.folder%27", "files(id,shared,name,kind,mimeType,parents,ownedByMe)", pageSize, pageToken)
+      var resp = global.gdrive.readdir(nil, "mimeType%20=%20%27application/vnd.google-apps.folder%27", "files(id,shared,name,kind,mimeType,parents,ownedByMe)", pageSize, pageToken)
       var files = resp['files']
       if !size(files)
         break
@@ -122,7 +122,7 @@ class gdrivetest
   end
 
   def mkdirtest(name)
-    var newfolderid = gdrive.mkdir(my_folder_id, name)
+    var newfolderid = global.gdrive.mkdir(my_folder_id, name)
     if newfolderid
       print('mkdir ' .. name .. ' success')
     end
@@ -130,7 +130,7 @@ class gdrivetest
   
   def finddirtest(name)
     print('find folder id for ' .. name)
-    var folders = gdrive.readdir(shared_folder_id, "name%20=%20%27" .. name .. "%27", "files(id)")
+    var folders = global.gdrive.readdir(my_folder_id, "name%20=%20%27" .. name .. "%27", "files(id)")
     print(folders)
     var id = nil
     if folders && folders['files']
@@ -170,17 +170,17 @@ class gdrivetest
       return
     end
     if self.teststep == 3
-      print('search for folder testfolder')
       var id = self.finddirtest('testfolder')
       if id
         print('write testfolder/mytestfile.txt')
-        var resp = gdrive.write(id, 'mytestfile.txt', "text or bytes")
+        var resp = global.gdrive.write(id, 'mytestfile.txt', "text or bytes")
         print(resp)
         print('read folder testfolder')
-        resp = gdrive.readdir(id)
+        resp = global.gdrive.readdir(id)
         print(resp)
+      else
+        print('testfolder not found')
       end
-      print('check your google drive for the new file testfolder/mytestfile.txt')
       self.teststep = 4
       return
     end
@@ -194,7 +194,7 @@ class gdrivetest
   end
 
   def clean(confirm)
-    gdrive.cleanservicefiles(confirm)
+    global.gdrive.cleanservicefiles(confirm)
     if !confirm
       print('if the files to be deleted look correct, use gtest.clean(true) to delete them')
       print('THIS WILL DELETE ALL UNUSED SERVICE OWNED FILES\n - YOU MAY WISH TO REVIEW THE CODE FIRST\n ONLY USE FOR SERVICE ACCOUNTS DEDICATED TO TASMOTA PURPOSE')


### PR DESCRIPTION
bugfixes found when using on a freshly booted device....
Existing global variables in berry confound testing sometimes....
We should highlight for contributions that they should be tested on a fresh boot and without autoexec.be?